### PR TITLE
fix(tui): add delay to allow terminal to render properly on mode switch

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -15049,8 +15049,21 @@ pub fn run_tui_with_background(
         ViewMode::Attention => model.compute_attention(),
         _ => {}
     }
+    // The default 16ms frame budget is tuned for warm, steady-state
+    // rendering. A cold first frame (large issue counts, uncached layout
+    // computation) routinely exceeds that, and ftui silently drops the
+    // present step for any frame that overruns its budget rather than
+    // showing it late — so without a larger budget the very first frame
+    // never reaches the terminal, leaving a blank screen until the next
+    // event happens to render within budget.
+    let budget = ftui::render::budget::FrameBudgetConfig {
+        total: std::time::Duration::from_millis(500),
+        allow_frame_skip: false,
+        ..ftui::render::budget::FrameBudgetConfig::default()
+    };
     App::new(model)
         .screen_mode(ScreenMode::AltScreen)
+        .with_budget(budget)
         .run()
         .map_err(|error| BvrError::Tui(error.to_string()))
 }


### PR DESCRIPTION
greetings, and thanks for beads by the way. i wanted to test this new tui and the tree, graph mode and history are golden, but well that's not the point.
    
I tried the tui on a project with about 800 tasks and it gives a blank screen at start, then pressing the defined keys switches views but eventually there is flickering, colors disappear, screen locks: this pr fixes it hopefully

i just noticed also a few things, `h` for History is probably not the best choice since it's also for navigation, i wasnt able to enter the History pressing keys in the tui, just using `bvr --view history`, but should I then press `a` and go to the Actionnables i cant go back and press `h` to history, Another key may be preferable imho.
