### PR TITLE
fix(tui): start with first sorted issue selected instead of index 0

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -14925,10 +14925,44 @@ fn new_app_with_background(
     };
     let slow_metrics_pending = use_two_phase;
 
+    // Compute the first visible issue index using the same filtering and sorting
+    // logic that will be applied in visible_issue_indices(). By default, this
+    // filters by open status and sorts by priority, then by ID.
+    let temp_app_selected = {
+        let mut visible = analyzer
+            .issues
+            .iter()
+            .enumerate()
+            .filter_map(|(index, issue)| {
+                if issue.normalized_status().eq_ignore_ascii_case("closed") {
+                    None
+                } else {
+                    Some(index)
+                }
+            })
+            .collect::<Vec<_>>();
+
+        // Use the default sort: open status, then priority, then ID.
+        // This matches ListSort::Default in the main list.
+        visible.sort_by(|left_index, right_index| {
+            let left_issue = &analyzer.issues[*left_index];
+            let right_issue = &analyzer.issues[*right_index];
+
+            let l_open = left_issue.is_open_like();
+            let r_open = right_issue.is_open_like();
+            r_open
+                .cmp(&l_open)
+                .then_with(|| left_issue.priority.cmp(&right_issue.priority))
+                .then_with(|| left_issue.id.cmp(&right_issue.id))
+        });
+
+        visible.first().copied().unwrap_or(0)
+    };
+
     BvrApp {
         analyzer,
         repo_root,
-        selected: 0,
+        selected: temp_app_selected,
         list_filter: ListFilter::All,
         list_sort: ListSort::Default,
         board_grouping: BoardGrouping::Status,


### PR DESCRIPTION
The TUI was initializing with `selected = 0`, which refers to the first issue in the unsorted analyzer.issues vector. However, the list display renders issues in sorted order (by open status, priority, then ID). This mismatch caused the visual cursor marker (>) to appear on an issue that wasn't visually at the top of the list — typically showing the 14th issue instead of the first.

Now `new_app_with_background` computes the first visible issue using the same filtering and sorting logic as `visible_issue_indices()`, ensuring the TUI starts with the correct issue selected and visible at the top of the list.